### PR TITLE
fix: CQDG-1467 use composite primary key (hash, entity_type) for id_map

### DIFF
--- a/docker/init_postgresql.sql
+++ b/docker/init_postgresql.sql
@@ -1,7 +1,8 @@
 CREATE TABLE id_map (
-    hash varchar(255) PRIMARY KEY,
+    hash varchar(255) NOT NULL,
     internal_id varchar(50) NOT NULL,
-    entity_type varchar(50),
+    entity_type varchar(50) NOT NULL,
+    PRIMARY KEY (hash, entity_type),
     UNIQUE (internal_id, entity_type)
 );
 

--- a/src/services/idGenerationService.ts
+++ b/src/services/idGenerationService.ts
@@ -81,11 +81,10 @@ export async function findOrCreateMappingForGivenInternalID(
     //Those not found should be created here:
     if (!results.rows || results.rowCount === 0) {
       try {
-        await client.query('INSERT INTO id_map (hash, internal_id, entity_type) VALUES ($1, $2, $3)', [
-          hash,
-          internalID,
-          entityType,
-        ]);
+        await client.query(
+          'INSERT INTO id_map (hash, internal_id, entity_type) VALUES ($1, $2, $3) ON CONFLICT (hash, entity_type) DO NOTHING',
+          [hash, internalID, entityType]
+        );
 
         results = await client.query('SELECT internal_id FROM id_map WHERE entity_type = $1 AND hash = $2', [
           entityType,
@@ -160,7 +159,10 @@ async function fetchMissing(notFoundHashes: string[], entityType: string, client
   try {
     //Create missing entries
     console.debug(`Creating ${values.length} missing entries`, new Date().toLocaleString());
-    await client.query(format('INSERT INTO id_map (hash, internal_id, entity_type) VALUES %L', values), []);
+    await client.query(
+      format('INSERT INTO id_map (hash, internal_id, entity_type) VALUES %L ON CONFLICT (hash, entity_type) DO NOTHING', values),
+      []
+    );
 
     //Fetch Missing entries
     console.debug(`Fetching ${values.length} missing entries`, new Date().toLocaleString());


### PR DESCRIPTION
## 📌 Context

The `/batch/create` endpoint started returning `500 duplicate key value violates unique constraint "id_map_pkey"` after the new `file_hash` entity type was introduced (CQDG-1418).

Root cause: the `id_map` table's primary key was on `hash` alone, but all lookup logic keys on `(hash, entity_type)`. When a content hash already stored as one entity type (e.g. `file`) arrives under a different entity type (e.g. `file_hash`), the entity-type-filtered `SELECT` doesn't find it, the row is treated as missing, and the subsequent `INSERT` collides on the bare `hash` PK. Since `file` and `file_hash` are deliberately separate entities (distinct prefixes/sequences) that share the same content hash, `(hash, entity_type)` must be the natural key.

## 📝 Changes

- Changed `id_map` primary key from `hash` to composite `(hash, entity_type)` and made `entity_type` `NOT NULL` (`docker/init_postgresql.sql`).
- Added `ON CONFLICT (hash, entity_type) DO NOTHING` to both insert paths in `src/services/idGenerationService.ts` (`fetchMissing` batch insert and `findOrCreateMappingForGivenInternalID`) so concurrent batches no longer 500 on a race; both paths re-select after insert, so behaviour is unchanged on success.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [CQDG-1467](https://ferlab-crsj.atlassian.net/browse/CQDG-1467)
<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- The PK change requires an in-place migration of the existing `id_map` table (`DROP CONSTRAINT id_map_pkey` → `ADD PRIMARY KEY (hash, entity_type)`); the idempotent `DO` block handling this lives in the k8s repo's `id-service-schema.sql`. It raises if any row has `entity_type IS NULL`, so legacy NULLs must be resolved first.

[CQDG-1467]: https://ferlab-crsj.atlassian.net/browse/CQDG-1467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ